### PR TITLE
Fix logic when adding a value which could go into multiple centroids

### DIFF
--- a/serde_test.go
+++ b/serde_test.go
@@ -31,6 +31,12 @@ func TestMarshalRoundTrip(t *testing.T) {
 	t.Run("empty", testcase(New()))
 	t.Run("1 value", testcase(simpleTDigest(1)))
 	t.Run("1000 values", testcase(simpleTDigest(1000)))
+
+	d := New()
+	d.Add(1, 1)
+	d.Add(1, 1)
+	d.Add(0, 1)
+	t.Run("1, 1, 0 input", testcase(d))
 }
 
 func TestUnmarshalErrors(t *testing.T) {


### PR DESCRIPTION
When adding a value, we pick a centroid for it to be added to. Usually, there is just one option, the centroid with the nearest mean. In some cases (typically when a TDigest has very few values), it's possible for multiple centroids to have means which are equidistant from the input value.

The previous logic for this was broken in that it did not carefully maintain the invariant that the centroid means should always be non-decreasing. Previously, we would first filter the candidate set to only a set of centroid which have room for more values, and then we would filter again to preserve the invariant. This was backwards.

Instead, we need to first make sure the invariant is preserved. If the right centroid is full, we just need to add a new one. Other logic (in `addNewCentroid`) will make sure it's added in the right spot.

Fixes #6.